### PR TITLE
Add workflow for releasing and publishing versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release Version
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dschep/install-poetry-action@v1.3
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+  
+      - name: Update pip
+        run: |
+          python -m pip install --upgrade pip
+    
+      - name: Install project dependencies
+        run: |
+          poetry install
+
+      - name: Bump release version
+        run: poetry version $( echo '${{ github.ref }}' | sed 's/refs\/tags\///' )
+
+      - name: Build package
+        run: poetry build
+
+      - name: Publish package (Test PyPI)
+        run: |
+          poetry config repositories.testpypi https://test.pypi.org/legacy/
+          poetry config pypi-token.testpypi ${{ secrets.TEST_PYPI_PASSWORD }}
+          poetry publish -r testpypi
+
+      - name: Publish package (PyPI)
+        run: |
+          poetry config pypi-token.pypi ${{ secrets.PYPI_PASSWORD }}
+          poetry publish


### PR DESCRIPTION
This PR adds a workflow to build and publish a new version to PyPI when a tag is created that starts with `v`. Closes #5.

# Caveats

This workflow [currently fails](https://github.com/shawalli/aws-coco/runs/1201665283?check_suite_focus=true) because the PyPI and Test PyPI creds are not yet set up. Once the credentials are set up for both indexes, this workflow should work.